### PR TITLE
Support for setting AWS S3 configuration via ENV

### DIFF
--- a/kadira-ui/client/components/app.tools.cpu/component.js
+++ b/kadira-ui/client/components/app.tools.cpu/component.js
@@ -200,7 +200,7 @@ component.prototype.jobId = function() {
 component.prototype.loadRemoteProfile = function(id) {
   this.set("profile", null);
   var self = this;
-  var url = "https://profdata.kadira.io/" + id + ".js";
+  var url = Meteor.settings.public.s3Url + id + ".js";
   var headers = {headers: {"Content-Type": "application/json"}};
   HTTP.get(url, headers, function(error, result){
     if(error && error.response.statusCode === 403){

--- a/kadira-ui/packages/jobs/lib/server/methods.js
+++ b/kadira-ui/packages/jobs/lib/server/methods.js
@@ -2,16 +2,30 @@ var AWS = Npm.require('aws-sdk');
 
 var createAWSFile = function(jobId, callback){
   callback = callback || function(){};
-  var s3 = new AWS.S3();
+  AWS.config.update({
+    signatureVersion: 'v4'
+  });
+  if(!process.env.AWS_BUCKET){
+    throw new Error('plese set the env AWS_BUCKET');
+    process.exit(1);
+  }
+  if(!process.env.AWS_DEFAULT_REGION){
+    throw new Error('plese set the env AWS_DEFAULT_REGION');
+    process.exit(1);
+  }
 
-  AWS.config.region = 'us-east-1';
+  var s3 = new AWS.S3({
+   endpoint: 's3-'+ process.env.AWS_DEFAULT_REGION +'.amazonaws.com',
+   signatureVersion: 'v4',
+   region: process.env.AWS_DEFAULT_REGION
+  });
+
   var params = {
-    Bucket: 'profdata.kadira.io',
+    Bucket: process.env.AWS_BUCKET,
     ContentType: 'application/json',
     ACL: 'public-read'
   };
   params['Key'] = jobId + '.js';
-
   s3.getSignedUrl('putObject', params, callback);
 }
 

--- a/kadira-ui/server/config/aws_s3.js
+++ b/kadira-ui/server/config/aws_s3.js
@@ -1,0 +1,3 @@
+Meteor.startup(function() {
+  Meteor.settings.public.s3Url = process.env.AWS_S3_URL;
+});


### PR DESCRIPTION
Most of these changes are taken directly from: lampe/kadira-server but I was already using this repo and want to add the same functionality here.

This PR allows the following environment variables to be set in order to use the debugger & profiler:

            AWS_DEFAULT_REGION 
            AWS_ACCESS_KEY_ID
            AWS_SECRET_ACCESS_KEY
            AWS_S3_URL

Hopefully this is useful to someone.